### PR TITLE
Update primary URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,7 +12,7 @@ bootswatch_theme: "united"
 
 # These settings are always used by Jekyll
 title: "Baton Rouge DSA"
-url: https://brdsa.dsachapters.org
+url: https://brdsa.org
 
 # These settings ase used by the jekyll-seo-tag plugin. The plugin adds
 # metadata tags for search engines and social networks to better index and


### PR DESCRIPTION
Now that the DNS records for brdsa.org are configured, we should link to that URL.