### PR TITLE
fix build, remove duplicate import

### DIFF
--- a/src/routes/fite/recipes/[slug]/+page.svelte
+++ b/src/routes/fite/recipes/[slug]/+page.svelte
@@ -3,7 +3,6 @@
 	import PaletteHeader from "$lib/components/PaletteHeader.svelte";
 	import Prose from "$lib/components/Prose.svelte";
 	import Link from "$lib/components/Link.svelte";
-	import Link from "$lib/components/Link.svelte";
 	import { getSummary } from "$lib/recipeUtils.js";
 	let { data } = $props();
 	let post = $derived(data.post);


### PR DESCRIPTION
from the most recent failed build output, there was this error "Identifier 'Link' has already been declared". the `import Link` line was accidentally duplicated on this page. this could have been caught by running `npm run build` locally rather than just `npm run dev`, so that's my bad. fortunately it's a trivial fix 

vite v7.3.1 building ssr environment for production...
transforming...
✓ 14 modules transformed.
✗ Build failed in 199ms
error during build:
[vite-plugin-svelte:compile] [plugin vite-plugin-svelte:compile] src/routes/fite/recipes/[slug]/+page.svelte (6:8): /home/runner/work/brdsa.github.io/brdsa.github.io/src/routes/fite/recipes/[slug]/+page.svelte:6:8 Identifier 'Link' has already been declared
https://svelte.dev/e/js_parse_error
file: /home/runner/work/brdsa.github.io/brdsa.github.io/src/routes/fite/recipes/[slug]/+page.svelte:6:8

 4 |    import Prose from "$lib/components/Prose.svelte";
 5 |    import Link from "$lib/components/Link.svelte";
 6 |    import Link from "$lib/components/Link.svelte";
               ^
 7 |    import { getSummary } from "$lib/recipeUtils.js";
 8 |    let { data } = $props();